### PR TITLE
Add group add to readme

### DIFF
--- a/README
+++ b/README
@@ -123,6 +123,12 @@ Raspberry Pi 4/5:
 	While using the outdated fkms driver still works with this plugin, there might be
 	some problems when viewing interlaced material and displaying the OSD.
 
+	The 'vdr' user needs to be added to 'audio' and 'render' to access /dev/snd/* and
+	/dev/dri/render*:
+
+	usermod -a -G audio vdr
+	usermod -a -G render vdr
+
 Requirements:
 -------------
         No running X!


### PR DESCRIPTION
Otherwise a warning is logged saying "No such file or directory" when opening the default alsa device, and playback doesn't work.